### PR TITLE
De-slop the book: pyramid structure, précis content, STE sentences

### DIFF
--- a/docs/book/00_introduction.md
+++ b/docs/book/00_introduction.md
@@ -1,47 +1,41 @@
-# 00 — Introduction
+# 00. Introduction
 
-A hands-on walkthrough of Domain-Driven Design fundamentals, using Gleam to
-make the patterns *enforceable* rather than aspirational. Each chapter pairs
-one DDD concept with the small set of Gleam features that make it
-compile-time true.
+Gleam makes the core DDD patterns *enforceable* rather than aspirational.
+Each chapter pairs one Domain-Driven Design concept with the small set of
+Gleam features that make it compile-time true.
 
-It's not a survey of DDD, and it's not a Gleam tutorial. It's the
-intersection — the place where the language and the methodology compound on
-each other.
+This is neither a DDD survey nor a Gleam tutorial. It covers the
+intersection, where the language and the methodology compound.
 
 ---
 
-## What DDD actually is
+## DDD makes business rules the load-bearing structure
 
-Domain-Driven Design is a way of organizing software so that the
-**vocabulary**, **boundaries**, and **invariants** of the business are the
-load-bearing structure of the code, not an afterthought layered on top of
-CRUD models.
+Domain-Driven Design makes the **vocabulary**, **boundaries**, and
+**invariants** of the business the load-bearing structure of the code.
+They are not a layer on top of CRUD models.
 
-Three ideas do most of the work:
+The ideas below do most of the work; the familiar patterns (Repositories,
+Factories, Anti-Corruption Layers) are consequences of them.
 
-1. **Make illegal states unrepresentable.** If "an order with zero lines cannot be placed" is a rule, the code shouldn't *check* it everywhere — the type should *forbid* it.
-2. **Concepts have shapes.** A `CustomerId` is not a `String`. A `Money` is not a number. Modeling them as their own types makes the rest of the system more honest about what it does.
-3. **Behavior lives with the data.** "An order is placed" isn't a flag flip in a service somewhere — it's a method on the order itself, with its own preconditions, returning either a new state or a typed reason it can't transition.
-
-Most introductions to DDD bury these ideas in patterns (Repositories,
-Factories, Anti-Corruption Layers). The patterns are real, but they're
-*consequences*. The cause is those three ideas above.
+1. **Make illegal states unrepresentable.** If "an order with zero lines cannot be placed" is a rule, the type should *forbid* it; the code shouldn't *check* it everywhere.
+2. **Concepts have shapes.** A `CustomerId` is not a `String`, and a `Money` is not a number. Modeling them as their own types makes the rest of the system honest about what it does.
+3. **Behavior lives with the data.** "An order is placed" isn't a flag flip in a service; it's an operation on the order itself. It has preconditions and returns either a new state or a typed reason the transition failed.
 
 ---
 
-## Why Gleam
+## Gleam's constraints map onto DDD's demands
 
 Gleam is small. The whole language has the feel of a careful editor's pass:
-nothing extra, nothing fancy, no escape hatches.
+nothing extra, and no escape hatches.
 
-- **[Algebraic data types](https://tour.gleam.run/data-types/custom-types/)** with exhaustive [pattern matching](https://tour.gleam.run/flow-control/case-expressions/). Every alternative gets named; the compiler refuses to let you forget one.
-- **[Opaque types](https://tour.gleam.run/advanced-features/opaque-types/)** — a one-keyword feature that lets a module hide its constructor. Outside the module, the type exists; the only way to make one is through functions you expose.
+- **[Algebraic data types](https://tour.gleam.run/data-types/custom-types/)** with exhaustive [pattern matching](https://tour.gleam.run/flow-control/case-expressions/). You name every alternative; the compiler refuses to let you forget one.
+- **[Opaque types](https://tour.gleam.run/advanced-features/opaque-types/)**: one keyword lets a module hide its constructor. Outside the module the type exists, and the only way to make one is through functions the module exposes.
 - **No exceptions, no nulls.** Failure is a value ([`Result(a, e)`](https://tour.gleam.run/data-types/results/), `Option(a)`). Callers can't pretend it didn't happen.
 - **No `if`.** Every branch is a [`case`](https://tour.gleam.run/flow-control/case-expressions/), which forces you to consider the alternatives.
-- **One control-flow primitive ([`use <-`](https://tour.gleam.run/advanced-features/use/))** that handles guards, chaining, resource handling, and any custom flow you'd write — with a single syntactic rule.
+- **One control-flow primitive ([`use <-`](https://tour.gleam.run/advanced-features/use/))** that handles guards, chaining, resource handling, and any custom flow you'd write, under one syntactic rule.
 
-Each of these maps almost suspiciously onto what DDD wants:
+Each maps almost suspiciously well onto what DDD wants:
 
 | DDD wants...                             | Gleam gives you...                            |
 | ---------------------------------------- | --------------------------------------------- |
@@ -56,44 +50,38 @@ Gleam happens to be the right shape for the job.
 
 ---
 
-## Why this kata progression
+## The katas add one concept at a time
 
-The progression goes:
+1. **Value Objects**: `Email`, `Money`. Build the simplest unit. Practice opaque types, smart constructors, error sums, `use` chaining.
+2. **Entities**: `Customer`. Same toolkit, but now identity matters. Practice ID types, equality semantics, state transitions as new immutable values.
+3. **Aggregates**: `Order` + `OrderLine`. Multiple internal pieces, invariants spanning them all. Practice hiding internals, designing a single front door.
+4. **Domain Events**: `OrderPlaced` and friends. State transitions that *also* report what happened.
 
-1. **Value Objects** — `Email`, `Money`. Build the simplest unit. Practice opaque types, smart constructors, error sums, `use` chaining.
-2. **Entities** — `Customer`. Same toolkit, but now identity matters. Practice ID types, equality semantics, state transitions as new immutable values.
-3. **Aggregates** — `Order` + `OrderLine`. Multiple internal pieces, invariants spanning them all. Practice hiding internals, designing a single front door.
-4. **Domain Events** — `OrderPlaced`, etc. State transitions that *also* report what happened. (Coming in a later chapter.)
-
-Each kata adds **one** new DDD concept. Each chapter introduces **only the
-Gleam features needed for that concept.** By the end you can read or write
-idiomatic domain code in Gleam without having to learn either subject in the
+Each kata adds **one** new DDD concept, and each chapter introduces **only
+the Gleam features that concept needs.** By the end you can read and write
+idiomatic domain code in Gleam without learning either subject in the
 abstract first.
 
 ---
 
-## How to read this
-
-Each chapter follows the same shape:
+## Each chapter follows one shape
 
 - **Concept.** The DDD idea in plain language.
-- **Gleam fundamentals you need.** Just enough — no full language tour.
+- **New Gleam fundamentals.** Only what this kata needs.
 - **The task.** A function signature and rules. Implement it.
-- **Hints / what to do.** Nudges to unblock without spoiling the design.
-- **A walk-through.** The reference solution, with reasoning.
-- **Critique.** What's solid, what could be tightened, what changes when the system grows.
-- **DDD takeaway.** What the code now *guarantees*, and why that matters past the toy example.
+- **Hints.** Nudges that unblock without spoiling the design.
+- **Walk-through.** The reference solution, with reasoning.
+- **Critique.** What holds, what doesn't, what changes as the system grows.
+- **DDD takeaway.** The property the code now *guarantees*, and why it matters past the toy example.
 
 The exercises are real. Type the code. Try to satisfy the tests. Then read
 the walk-through.
 
 ---
 
-## Gleam resources
+## Keep these tabs open
 
-Useful tabs to keep open while you work through the book:
-
-- **[The Gleam Language Tour](https://tour.gleam.run/)** — interactive, in-browser. The single best place to look up any language feature.
-- **[Standard library reference](https://hexdocs.pm/gleam_stdlib/)** — `gleam/string`, `gleam/list`, `gleam/result`, etc. You'll reach for these in every kata.
-- **[Gleam documentation index](https://gleam.run/documentation/)** — guides, cheatsheets (including a [Gleam-for-Rust](https://gleam.run/cheatsheets/gleam-for-rust-users/) and [Gleam-for-Elixir](https://gleam.run/cheatsheets/gleam-for-elixir-users/) one), conventions.
-- **[Gleam home](https://gleam.run/)** — install instructions if you don't already have the `gleam` CLI.
+- **[The Gleam Language Tour](https://tour.gleam.run/)**: interactive, in-browser. The best place to look up any language feature.
+- **[Standard library reference](https://hexdocs.pm/gleam_stdlib/)**: `gleam/string`, `gleam/list`, `gleam/result`, etc. You'll reach for these in every kata.
+- **[Gleam documentation index](https://gleam.run/documentation/)**: guides, conventions, and cheatsheets, including [Gleam-for-Rust](https://gleam.run/cheatsheets/gleam-for-rust-users/) and [Gleam-for-Elixir](https://gleam.run/cheatsheets/gleam-for-elixir-users/).
+- **[Gleam home](https://gleam.run/)**: install instructions if you don't have the `gleam` CLI.

--- a/docs/book/01_fundamentals.md
+++ b/docs/book/01_fundamentals.md
@@ -1,16 +1,15 @@
-# 01 — Gleam fundamentals for Kata 1
+# 01. Gleam fundamentals for Kata 1
 
-This chapter gives you exactly the Gleam you need to do the first exercise.
-Every concept here will be reused in later katas — we add to the toolkit one
-chapter at a time.
-
-If you already know Gleam, skim the headers and skip ahead.
+Kata 1 needs this toolkit: sum types, records, `opaque`, `Result`, smart
+constructors, `case`, and modules. Later katas reuse every piece. If you
+already know Gleam, skim the headers and skip ahead.
 
 ---
 
-## Sum types (a.k.a. enums, tagged unions, ADTs)
+## Sum types: a fixed set of named variants
 
-A custom type is declared as a fixed set of *variants*:
+You declare a custom type as a fixed set of *variants*. Other languages
+call these enums, tagged unions, or ADTs.
 
 ```gleam
 pub type Currency {
@@ -21,8 +20,7 @@ pub type Currency {
 ```
 
 A value of `Currency` is *exactly one of* `USD`, `EUR`, or `GBP`. There are
-no other values. You can't have `null`, you can't have `"USD"` masquerading
-as one.
+no other values: no `null`, and no `"USD"` masquerading as one.
 
 Variants can carry data:
 
@@ -34,14 +32,14 @@ pub type Shape {
 ```
 
 `Circle(3.0)` and `Rectangle(2.0, 5.0)` are both valid `Shape` values. Same
-type, different shapes — hence "sum type."
+type, different shapes; hence "sum type."
 
 ---
 
-## Records (variants with named fields)
+## Records: one variant with named fields
 
 A type with a single variant whose name matches the type is the Gleam
-equivalent of a record/struct:
+equivalent of a record or struct:
 
 ```gleam
 pub type Email {
@@ -54,7 +52,7 @@ type and the variant share a name; this is idiomatic.
 
 ---
 
-## `opaque` — the one-keyword superpower
+## `opaque`: only the module can construct the type
 
 By default the constructor of a custom type is exported alongside the type
 itself. Add `opaque` and the constructor stays private to the module:
@@ -73,14 +71,14 @@ Outside this module:
 
 The only way to obtain an `Email` is to call a function that the module
 deliberately exports. That function can validate, normalize, do whatever it
-wants — and the type system guarantees nothing else gets through.
+wants, and the type system guarantees nothing else gets through.
 
 This is the mechanical foundation for "make illegal states unrepresentable."
-**Forgetting `opaque` is the single most common mistake when starting out.**
+**Forgetting `opaque` is the most common beginner mistake.**
 
 ---
 
-## `Result(a, e)` — failure as a value
+## `Result(a, e)`: failure is a value
 
 Gleam has no exceptions. A function that can fail returns a `Result`:
 
@@ -95,13 +93,13 @@ pub type Result(a, e) {
 Conventional usage: `Result(ValidThing, SomeError)`. `Ok(v)` carries the
 success value; `Error(e)` carries why it failed.
 
-Callers must `case` on the result to see either branch — there's no way to
+Callers must `case` on the result to see either branch; there's no way to
 "just get the value" without acknowledging failure. (`let assert Ok(x) =
 ...` exists for crash-on-error scenarios, mostly tests.)
 
 ---
 
-## Smart constructors
+## Smart constructors: the only door in
 
 A *smart constructor* is the function the outside world calls to make an
 opaque value. It runs validation, then either wraps the value in the type
@@ -114,11 +112,11 @@ pub fn new(raw: String) -> Result(Email, EmailError) {
 ```
 
 By convention this function is called `new`. Because the type is `opaque`,
-this is the *only door* — there's no shortcut around it.
+this is the *only door*; there's no shortcut around it.
 
 ---
 
-## `case` — Gleam's only conditional
+## `case`: the only conditional, checked for exhaustiveness
 
 There is no `if`. There is `case`, which pattern-matches on a value:
 
@@ -131,14 +129,14 @@ case x {
 ```
 
 The compiler checks **exhaustiveness**. If you `case` on a sum type and
-miss a variant, it's a compile error. This is what makes "named failure
-modes" not just a discipline but an enforced one.
+miss a variant, it's a compile error. That turns "named failure modes"
+from a discipline into an enforced property.
 
 `_` matches anything. Use it as the catch-all when the rest are explicit.
 
 ---
 
-## Pattern matching on shapes
+## Patterns match structure, not just values
 
 The killer feature: `case` doesn't just compare values, it matches
 *structure*.
@@ -155,19 +153,19 @@ case string.split(input, "@") {
 ```
 
 Each pattern names a *shape* the data could have. There are no chained
-`if/else` clauses — the structure of the data *is* the structure of the
+`if/else` clauses; the structure of the data *is* the structure of the
 validation.
 
-This is the most surprising thing if you come from imperative languages:
-pieces of code that you'd write as a sequence of guards (`if (!hasAt) ...
-else if (!domain) ...`) collapse into one `case` expression.
+This is the most surprising part if you come from imperative languages.
+Code you'd write as a sequence of guards (`if (!hasAt) ... else if
+(!domain) ...`) collapses into one `case` expression.
 
 **Order of patterns matters when they overlap.** `[""]` must come before
-`[_]`, because the empty string matches both — and `case` picks the first.
+`[_]`, because the empty string matches both, and `case` picks the first.
 
 ---
 
-## Modules and imports
+## Modules: one file, one namespace
 
 One file = one module. The filename is the module name. Public items use
 `pub`:
@@ -179,8 +177,7 @@ import email         // sibling module in the same project
 pub fn foo() { string.trim("  hi  ") }
 ```
 
-Pieces from a module are accessed `module.name`. You can pull specific
-names in:
+You access module items as `module.name`. You can pull specific names in:
 
 ```gleam
 import email.{type Email}  // brings the type into scope unqualified
@@ -193,9 +190,7 @@ unqualified.
 
 ---
 
-## What you have so far
-
-Just enough vocabulary:
+## That toolkit is enough for Kata 1
 
 - Define a type with one or many variants.
 - Mark it `opaque` so only your module can build it.
@@ -203,5 +198,4 @@ Just enough vocabulary:
 - Validate by `case`-matching on the structure of the input.
 - Return either `Ok(YourType(...))` or `Error(NamedReason)`.
 
-That toolkit is sufficient for Kata 1. **Don't read further until you've
-attempted the kata.**
+**Don't read further until you've attempted the kata.**

--- a/docs/book/02_kata_email.md
+++ b/docs/book/02_kata_email.md
@@ -1,17 +1,17 @@
-# 02 — Kata 1: Value Objects (`Email`)
+# 02. Kata 1: Value Objects (`Email`)
 
 ## Concept
 
-A **value object** is defined entirely by its attributes. Two `Email`s with
-the same string are the same email. There's no identity — there's nothing
-to identify. They're like numbers: `5` and `5` are the same `5`.
+A **value object** is nothing but its attributes. Two `Email`s with the
+same string are the same email. There's no identity; there's nothing to
+identify. They're like numbers: `5` and `5` are the same `5`.
 
-The crucial move is that **you cannot construct an invalid one.** Validation
-happens at the boundary where strings come in. After that, the rest of your
-code can take an `Email` parameter and *trust it*. No defensive checks. No
-"did someone forget to validate this?" anxiety.
+The crucial move: **you cannot construct an invalid one.** Validation
+happens once, at the boundary where strings come in. After that, code that
+takes an `Email` parameter *trusts it*, with no defensive checks.
 
-In Gleam the move is: **opaque type, smart constructor returning `Result`.**
+In Gleam that means an **opaque type with a smart constructor returning
+`Result`.**
 
 ---
 
@@ -50,17 +50,17 @@ The tests in `test/email_test.gleam` are the spec. Run with `gleam test`.
 
 ---
 
-## Hints — what to do
+## Hints
 
-1. **Start by trimming.** `gleam/string` has `string.trim/1`. Get that out of the way before you do any structural checks; it removes a whole class of edge cases.
-2. **Don't reach for boolean guards.** Don't write `if has_at && local_is_non_empty && domain_is_non_empty`. There's no `if` in Gleam, but more importantly, there's a much cleaner shape available.
-3. **Think about what `string.split(trimmed, "@")` returns.** It's a `List(String)`. The *shape* of that list — its length, which elements are empty — is the validation. Sketch out every possible meaningful shape on paper before writing code.
+1. **Trim first.** `gleam/string` has `string.trim/1`. Do it before any structural checks; it removes a class of edge cases.
+2. **Don't reach for boolean guards.** Don't write `if has_at && local_is_non_empty && domain_is_non_empty`. There is no `if` in Gleam, and a cleaner shape is available.
+3. **Consider what `string.split(trimmed, "@")` returns.** It's a `List(String)`. The *shape* of that list (its length, which elements are empty) is the validation. Sketch every meaningful shape on paper before writing code.
 4. **Pattern order matters.** When two patterns can match the same input (e.g., `[""]` and `[_]`), put the more specific one first. The empty string matches both, but you want to call it `Empty`, not `MissingAt`.
-5. **Add error variants as you discover them.** The starter has `Empty` and `MissingAt`. You'll find at least two more meaningful failure modes. Name each one explicitly — that's the whole point of a sum-type error.
-6. **For `to_string`,** you need to read the inner field. That works *inside* the module (where the constructor is in scope). Outside this module it would not.
+5. **Add error variants as you discover them.** The starter has `Empty` and `MissingAt`. You'll find at least two more meaningful failure modes. Name each one explicitly; that's the point of a sum-type error.
+6. **For `to_string`:** read the inner field. Field access works inside the module, where the constructor is in scope; outside it does not.
 
 If you get stuck after 15–20 minutes, scroll down. The point is not to
-brute-force it — it's to internalize the pattern.
+brute-force it; it's to internalize the pattern.
 
 ---
 
@@ -103,23 +103,21 @@ pub fn to_string(email: Email) -> String {
 ## Walk-through
 
 **`opaque` is doing all the work.** Nothing outside this module can build
-an `Email` without calling `new`. That's the whole game with value objects.
+an `Email` without calling `new`. That's the game with value objects.
 
-**Pattern order matters.** `[""]` is checked before `[_]`, because an empty
-string after trimming would split into `[""]` (a list containing one empty
-string), which would also match `[_]`. When patterns overlap, the more
-specific one goes first.
+**Pattern order matters.** The `[""]` pattern comes before `[_]` because an
+empty trimmed string splits into `[""]`, which also matches `[_]`. When
+patterns overlap, the more specific one goes first.
 
 **Returning `Result(Email, EmailError)` instead of `Bool`.** A bool tells
-you yes/no. A typed error tells you *why* — and the compiler forces every
-caller to handle both branches. The information is preserved all the way
-to wherever the error is finally surfaced (an HTTP response, a CLI message,
-a log line).
+you yes/no. A typed error tells you *why*, and the compiler forces every
+caller to handle both branches. The information survives to wherever the
+error finally surfaces (an HTTP response, a CLI message, a log line).
 
 **Why `Ok(Email(trimmed))` and not `Ok(Email(local <> "@" <> domain))`.**
-Some solutions reconstruct the email from the split parts. Skip the rebuild
-— the split was for validation, not transformation. `trimmed` is already
-the right string.
+Some solutions reconstruct the email from the split parts. Skip the
+rebuild: the split was for validation, not transformation. `trimmed` is
+already the right string.
 
 ---
 
@@ -127,18 +125,17 @@ the right string.
 
 - The check `[_]` matches a single non-empty token (after splitting on `@`), which means there was no `@` in the input. The variant name `MissingAt` reads correctly here.
 - `[""]` only happens when `trimmed` is `""`. Trimming first is what folds whitespace-only inputs into the `Empty` case for free.
-- Naming variants like `MissingTextBeforeAt` reads better than `EmptyLocalPart` for the audience that actually sees these errors. (Domain language is part of the design.)
+- Naming variants like `MissingTextBeforeAt` reads better than `EmptyLocalPart` for the audience that sees these errors. (Domain language is part of the design.)
 
 ---
 
 ## DDD takeaway
 
-Anywhere in your codebase that has a parameter `email: Email`, you have a
-*compile-time guarantee* it's been validated. No defensive checks. No
-"did someone forget to validate this?" Validation happens once, at the
-boundary where strings come in, and the type system carries the proof
+Anywhere your codebase has a parameter `email: Email`, you hold a
+*compile-time guarantee* that validation ran. Validation happens once, at
+the boundary where strings come in, and the type system carries the proof
 everywhere else.
 
-That's the upfront ceremony you pay for. In return: every later layer of
-the system gets to assume the email is well-formed, because the type system
-won't let it be otherwise.
+That's the ceremony you pay up front. In return, every later layer assumes
+the email is well-formed, because the type system won't let it be
+otherwise.

--- a/docs/book/03_kata_money.md
+++ b/docs/book/03_kata_money.md
@@ -1,24 +1,24 @@
-# 03 — Kata 2: Value Objects with operations (`Money`)
+# 03. Kata 2: Value Objects with operations (`Money`)
 
 ## Concept
 
-Same shape as `Email` (opaque type, smart constructor) but now with two new
+Same shape as `Email` (opaque type, smart constructor) but with new
 pressures:
 
-1. **Composition.** A `Money` has *two* attributes — amount and currency — and they have to stay coherent.
+1. **Composition.** A `Money` has two attributes, amount and currency, and they must stay coherent.
 2. **Operations that can fail at the domain level.** Adding USD to EUR is nonsense; the type system should stop it.
 
-This is where DDD starts to feel less like "wrap your strings" and more like
-*encoding the rules of the domain into the types*. The type doesn't just
-store data — it carries the operations that respect its invariants.
+This is where DDD starts to feel less like "wrap your strings" and more
+like *encoding the rules of the domain into the types*. The type carries
+the operations that respect its invariants, not just data.
 
 ---
 
 ## New Gleam fundamentals
 
-You'll need two more concepts on top of what Kata 1 used.
+Kata 1's toolkit gains record updates and `use <-`.
 
-### Record update syntax
+### Record update: copy with overrides
 
 To produce a "modified" copy of a record without re-listing every field:
 
@@ -27,10 +27,9 @@ let updated = Money(..money, amount: 0)
 ```
 
 `..money` says "take all the fields from this value, then override the
-named ones." Critical for keeping aggregate code from drowning in field
-repetition.
+named ones," which keeps aggregate code from drowning in field repetition.
 
-### `use <-` — guards as functions
+### `use <-`: guards as functions
 
 Some logic appears as a precondition again and again:
 
@@ -71,15 +70,15 @@ pub fn add(a: Money, b: Money) -> Result(Money, MoneyError) {
 rest of your block into a callback and passes it as the helper's last
 argument.
 
-A few mechanical facts:
+The mechanics:
 
-- `use <-` (no binding) means the callback takes zero arguments — it's a guard.
-- `use x <- f(...)` (one binding) means the callback takes one argument — used for unwrapping (we'll see this in Kata 3).
+- `use <-` (no binding): the callback takes zero arguments; it's a guard.
+- `use x <- f(...)` (one binding): the callback takes one argument, used for unwrapping. (Kata 3 uses this.)
 - The helper decides whether to call the callback. If it doesn't (e.g., currency mismatch), it returns its own error directly.
 - The lowercase `t` in `Result(t, MoneyError)` is a *generic type variable*. It lets the helper work for callers whose body returns `Result(Money, ...)`, `Result(Order, ...)`, anything.
 
-This is the pattern that will let aggregates read top-to-bottom like a list
-of business rules. (For a deeper explainer, see [`docs/use.md`](../use.md).)
+This is the pattern that lets aggregates read top-to-bottom like a list of
+business rules. See [`docs/use.md`](../use.md) for a deeper explainer.
 
 ---
 
@@ -124,16 +123,16 @@ The tests in `test/money_test.gleam` are the spec.
 
 ---
 
-## Hints — what to do
+## Hints
 
 1. **Write the naive version first.** Each operation does its own checks: `subtract` checks currencies *and* checks the result isn't negative. `multiply` checks negativity. It will work and the tests will pass. Get there first.
 2. **Then look for duplication.** Once it works, you'll see two patterns repeating across the file:
    - Every operation that touches two `Money`s repeats the same currency check.
    - Every operation that produces a new `Money` independently re-checks the negative-amount rule.
-3. **Refactor: route everything through `new`.** If `new` is the single source of truth for the negative-amount invariant, then `subtract` doesn't need its own check, and `multiply` gets the check for free.
-4. **Refactor: lift the currency check into a helper.** Write `require_same_currency` with the shape from the fundamentals section. Use it via `use <-`. Suddenly every operation reads as `require same currency, then compute`.
-5. **`zero(money)` doesn't return `Result`.** Why? Because `0` is always valid — it can never violate the invariant. Lean on the types: when an operation is total, say so by leaving `Result` out of the return type.
-6. **Why does the test for `multiply(m, -1)` expect `NegativeAmount`?** Trace it through your implementation. If `multiply` routes through `new`, this falls out automatically — that's the point of funneling.
+3. **Refactor: route everything through `new`.** If `new` is the source of truth for the negative-amount invariant, then `subtract` doesn't need its own check, and `multiply` gets the check for free.
+4. **Refactor: lift the currency check into a helper.** Write `require_same_currency` with the shape from the fundamentals section. Use it via `use <-`. Every operation then reads as "require same currency, then compute."
+5. **`zero(money)` doesn't return `Result`.** Why? `0` is always valid; it can never violate the invariant. When an operation is total, say so by leaving `Result` out of the return type.
+6. **Why does the test for `multiply(m, -1)` expect `NegativeAmount`?** Trace it through your implementation. If `multiply` routes through `new`, this falls out automatically; that's the point of funneling.
 
 ---
 
@@ -200,14 +199,14 @@ pub fn zero(money: Money) -> Money {
 
 ## Walk-through
 
-**Funneling through `new`.** Every constructor path re-validates. `subtract`
-no longer needs its own `amount >= 0` check — `new` does it. `multiply`
-catches negative factors automatically — also `new`. The non-negative
-invariant exists in exactly *one place*, and you literally cannot construct
-a `Money` that violates it.
+**Funneling through `new`.** Every constructor path re-validates.
+`subtract` no longer needs its own `amount >= 0` check; `new` does it.
+`multiply` catches negative factors the same way. The non-negative
+invariant exists in exactly *one place*, and you cannot construct a
+`Money` that violates it.
 
-**`use <- require_same_currency(a, b)`.** The duplicate currency check from
-a naive solution gets pulled into a named helper. Each operation now reads
+**`use <- require_same_currency(a, b)`.** A named helper absorbs the
+duplicate currency check from the naive solution. Each operation now reads
 as a flat list of business rules:
 
 > require same currency, then sum.
@@ -223,19 +222,19 @@ pub fn add(a: Money, b: Money) -> Result(Money, MoneyError) {
 }
 ```
 
-`use` is *just sugar* for that callback shape. Once you can read one form,
-you can read the other.
+`use` is sugar for that callback shape. Once you can read one form, you
+can read the other.
 
-**`zero` is total.** No `Result`. The function can't fail — `0` always
-satisfies the non-negative rule. Use record update (`Money(..money, amount:
-0)`) so the currency comes along for free.
+**`zero` is total.** No `Result`. The function can't fail; `0` always
+satisfies the non-negative rule. Record update (`Money(..money, amount:
+0)`) brings the currency along for free.
 
-**Storing amounts as `Int` minor units.** Floats and money don't mix —
-`0.1 + 0.2 ≠ 0.3` in IEEE-754. Real systems store cents. This is a domain
-modeling decision encoded in the type.
+**Storing amounts as `Int` minor units.** Floats and money don't mix;
+`0.1 + 0.2 ≠ 0.3` in IEEE-754. Real systems store cents. The choice is a
+domain decision encoded in the type.
 
 **Why `add` returns `Result`.** In a primitive world `add(usd_5, eur_3)`
-silently gives you `8` of nothing. In a domain-modeled world, it's a
+silently gives you `8` of nothing. In a domain-modeled world it's a
 `CurrencyMismatch` you must handle. The bug becomes impossible to ignore.
 
 ---
@@ -254,5 +253,5 @@ passes every invariant. Callers cannot lie about currency. Callers cannot
 smuggle in negative amounts. Every `Money` in your system is, by
 construction, valid.
 
-This is what people mean by "make illegal states unrepresentable" — it's
-not a slogan, it's the literal property your type now has.
+This is what people mean by "make illegal states unrepresentable"; it's
+not a slogan but the literal property your type now has.

--- a/docs/book/04_kata_customer.md
+++ b/docs/book/04_kata_customer.md
@@ -1,22 +1,22 @@
-# 04 — Kata 3: Entities (`Customer`)
+# 04. Kata 3: Entities (`Customer`)
 
 ## Concept
 
 The conceptual shift: a customer named "Alice" who renames to "Alice Smith"
 tomorrow is *the same customer*. Identity persists; attributes change.
 
-Equality is by **ID**, not by value. Gleam's `==` will give you the wrong
-answer if you naively use it on entities — two snapshots of the same
-customer at different moments will compare unequal because their fields
-differ, but they represent one entity.
+Equality is by **ID**, not by value. Gleam's `==` gives the wrong answer on
+entities: two snapshots of the same customer compare unequal because their
+fields differ, yet they represent one entity.
 
 The fix is structural: give entities an explicit **ID type**, and don't
-compare entities with `==` at all — write a `same_X` function that compares
-by ID.
+compare entities with `==` at all; write a `same_X` function that compares
+by ID instead.
 
 This is the moment value objects start paying off. `Email` from Kata 1 is
-a building block here — `Customer` *contains* an `Email`, and there's no
-re-validation at the customer layer because the type already carries proof.
+a building block here: `Customer` *contains* an `Email`, and there's no
+re-validation at the customer layer because the type already carries
+proof.
 
 ---
 
@@ -30,12 +30,12 @@ import email.{type Email}
 
 This brings the *type* `Email` into scope by bare name (so you can write
 `email: Email` instead of `email: email.Email`). Functions are still
-namespaced (`email.new(...)`), only the type alias is unqualified.
+namespaced (`email.new(...)`); only the type alias is unqualified.
 
-### One-arg `use` — `result.try`
+### One-arg `use`: `result.try`
 
-Now we have two layers of types: `Customer` is built from `CustomerId` and
-`Email`, both smart-constructed. A boundary function that turns raw
+Now there are two layers of types: `Customer` is built from `CustomerId`
+and `Email`, both smart-constructed. A boundary function that turns raw
 strings into a `Customer` has to chain three potentially-failing
 constructions:
 
@@ -49,7 +49,7 @@ case email.new(raw_email) {
 }
 ```
 
-This is the pyramid `use` was made to flatten:
+This is the pyramid `use` exists to flatten:
 
 ```gleam
 use email <- result.try(email.new(raw) |> result.map_error(InvalidEmail))
@@ -61,7 +61,7 @@ new(id, raw_name, email)
 If `r` is `Error`, the whole expression returns that error. With `use`,
 the call site reads as a sequence of validations.
 
-`result.map_error(f)` is for when error types don't line up — you wrap the
+`result.map_error(f)` is for when error types don't line up; you wrap the
 inner error so it fits the outer type.
 
 You won't strictly need this for the minimal version of Kata 3, but it's
@@ -105,19 +105,19 @@ Rules:
 - `rename` and `change_email` return a *new* `Customer` with the same ID.
 - `same_customer` compares by ID only.
 
-The tests in `test/customer_test.gleam` are the spec. (Currently empty —
+The tests in `test/customer_test.gleam` are the spec. (Currently empty;
 add cases as you implement.)
 
 ---
 
-## Hints — what to do
+## Hints
 
 1. **This is mostly Kata 1 applied twice.** `CustomerId` is an opaque value object with its own smart constructor (`new_id`). `Customer` is an opaque entity whose constructor (`new`) takes already-validated value objects. Two layers, same pattern.
-2. **`change_email` doesn't return `Result`. Why?** Because its only argument that could be invalid is `new_email`, which is *already* an `Email`, *already* validated. There is nothing to fail. Notice how the value-object layer eliminates checks at the entity layer.
-3. **`rename` does return `Result`. Why?** Because `new_name: String` is raw input — it could be empty. Route it through `new` to reuse the empty-name check. Don't write the check twice.
-4. **For `same_customer`, plain `==` on `CustomerId` is the right tool.** It works because `CustomerId` is an opaque value object — the only way to construct one is through `new_id`, so any two `CustomerId`s in your program are validated. The opacity gives you trustworthy equality.
+2. **`change_email` doesn't return `Result`. Why?** Its only argument that could be invalid is `new_email`, which is *already* an `Email`, *already* validated. There is nothing to fail. The value-object layer eliminates checks at the entity layer.
+3. **`rename` does return `Result`. Why?** `new_name: String` is raw input; it could be empty. Route it through `new` to reuse the empty-name check. Don't write the check twice.
+4. **For `same_customer`, plain `==` on `CustomerId` is the right tool.** It works because `CustomerId` is an opaque value object: the only way to construct one is `new_id`, so every `CustomerId` in your program is validated. The opacity gives you trustworthy equality.
 5. **Don't add fields you don't need.** No `created_at`, no `version`, no `address`. The kata is about the entity-vs-value distinction; everything else is noise.
-6. **The strict `new` takes pre-validated values.** Don't accept raw strings here. There's a separate place (a "boundary factory") for taking raw input and producing a customer; we'll see it in `docs/use.md`. The split keeps each function honest about what it can fail on.
+6. **The strict `new` takes pre-validated values.** Don't accept raw strings here. Taking raw input and producing a customer belongs in a separate "boundary factory"; `docs/use.md` shows it. The split keeps each function honest about what it can fail on.
 
 ---
 
@@ -183,14 +183,14 @@ pub fn same_customer(a: Customer, b: Customer) -> Bool {
 
 ## Walk-through
 
-**Funneling `rename` through `new`** — same instinct from `Money`. `rename`
+**Funneling `rename` through `new`.** Same instinct as `Money`. `rename`
 doesn't write its own validation; it constructs a new customer through the
 smart constructor, which already checks the name. One free invariant
 check, one place to maintain it.
 
-**`Email` is now a building block.** No re-validating an email string here
-— the type carries proof. This compounding is why value objects pay off;
-entities get to assume their parts are well-formed.
+**`Email` is now a building block.** No re-validating an email string
+here; the type carries proof. This compounding is why value objects pay
+off: entities get to assume their parts are well-formed.
 
 **Why `same_customer` and not just `==`.** `alice_v1 == alice_v2` after a
 rename returns `False` (the structs differ structurally), but domain-wise
@@ -198,16 +198,16 @@ they're the same person. Naming the function forces callers to ask:
 structural equality or identity equality? For entities, almost always
 identity.
 
-Because `CustomerId` is opaque and constructed only via `new_id`, comparing
-`a.id == b.id` is safe — the IDs you're comparing are guaranteed to be
-well-formed.
+Because `CustomerId` is opaque and constructed only via `new_id`,
+comparing `a.id == b.id` is safe; the IDs you're comparing are guaranteed
+to be well-formed.
 
 ---
 
 ## Critique
 
 - `string.length(raw) == 0` is functionally correct but `string.is_empty(raw)` is cheaper (no traversal) and reads more obviously as the intent. The `new_id` solution above uses `is_empty`; `new` still uses `length`. Pick one and be consistent.
-- `new(... name: "   ")` succeeds as written — whitespace-only name passes. Whether that's a bug depends on the domain. The deeper point: every place a string enters your domain is a chance for invariants to slip in.
+- `new(... name: "   ")` succeeds as written; a whitespace-only name passes. Whether that's a bug depends on the domain. The deeper point: every place a string enters your domain is a chance for invariants to slip in.
 - The strict `new` is good design but inconvenient when you genuinely have raw input from an HTTP boundary. The fix is a separate `from_raw` boundary factory that calls `email.new`, `new_id`, and `new` in a `use`-chain. See `docs/use.md` §4 for the worked example.
 
 ---
@@ -215,9 +215,9 @@ well-formed.
 ## DDD takeaway
 
 You have a `Customer` whose attributes can change but whose identity is
-permanent and trusted. `rename` and `change_email` are *state transitions*
-— each produces a new immutable value representing the next moment in that
-customer's life.
+permanent and trusted. `rename` and `change_email` are *state
+transitions*; each produces a new immutable value representing the next
+moment in that customer's life.
 
 In an event-sourced system each transition would emit a `CustomerRenamed`
 or `EmailChanged` event, and the customer's full history would be

--- a/docs/book/05_kata_order.md
+++ b/docs/book/05_kata_order.md
@@ -1,17 +1,21 @@
-# 05 — Kata 4: Aggregates (`Order`)
+# 05. Kata 4: Aggregates (`Order`)
 
 ## Concept
 
 An **aggregate** is a cluster of related objects treated as a unit. One
-object — the **aggregate root** — is the only entry point; everything
+object, the **aggregate root**, is the only entry point; everything
 outside the aggregate goes through it. The root's job is to enforce
 **invariants that span multiple internal pieces.**
 
-Concrete example: an `Order` has `OrderLine`s. Rules like *"an order must
-have at least one line to be placed"* or *"every line in an order must be
-in the same currency"* are invariants no single line can enforce on its
-own — they're properties of the whole. So `OrderLine` stays internal, and
-`Order` is the only thing the outside world touches.
+Concrete example: an `Order` has `OrderLine`s. Some rules span multiple
+lines:
+
+- *"an order must have at least one line to be placed"*
+- *"every line in an order must be in the same currency"*
+
+No single line can enforce them; they're properties of the whole. So
+`OrderLine` stays internal, and `Order` is the only thing the outside
+world touches.
 
 This is the moment Gleam's module system starts pulling its weight. A
 module is the natural unit for an aggregate: what's `pub` is the
@@ -21,7 +25,7 @@ aggregate's API; what isn't is sealed inside.
 
 ## New Gleam fundamentals
 
-### Internal types (no `pub`)
+### Internal types: no `pub`, no name outside
 
 A type without `pub` is private to its module:
 
@@ -36,10 +40,9 @@ root `Order` exposes operations that *manipulate* lines internally, but no
 one outside can construct or hold one directly. This is the hard,
 type-system-enforced version of "don't reach into the aggregate."
 
-### Multiple guards in sequence
+### Guards stack
 
-`use <-` was useful in Kata 2 with one guard. With aggregate invariants
-you'll have several:
+Kata 2 used one `use <-` guard. Aggregate invariants need several:
 
 ```gleam
 pub fn add_line(order, sku, quantity, unit_price) {
@@ -51,16 +54,17 @@ pub fn add_line(order, sku, quantity, unit_price) {
 }
 ```
 
-Each line is one named precondition. Reads top-to-bottom like a spec.
+Each line is one named precondition; the function reads top-to-bottom like
+a spec.
 
-### `list.try_map` and `list.try_fold`
+### `list.try_map` and `list.try_fold`: fallible iteration
 
 Aggregating over a list where each step can fail:
 
-- `list.try_map(list, f)` — runs `f` on each element; short-circuits with the first `Error`. Returns `Result(List(b), e)`.
-- `list.try_fold(list, init, f)` — folds the list with a fallible combining function. Short-circuits.
+- `list.try_map(list, f)`: runs `f` on each element; short-circuits with the first `Error`. Returns `Result(List(b), e)`.
+- `list.try_fold(list, init, f)`: folds the list with a fallible combining function. Short-circuits.
 
-`order.total` uses both — multiply each line's price by its quantity (each
+`order.total` uses both: multiply each line's price by its quantity (each
 can fail), then sum the results (each addition can fail).
 
 ---
@@ -113,13 +117,13 @@ pub fn place(order: Order) -> Result(Order, OrderError)
 pub fn total(order: Order) -> Result(Money, OrderError)
 ```
 
-Aggregate invariants — the whole reason this type exists:
+Aggregate invariants, the reason this type exists:
 
 1. `add_line` rejects empty SKUs and non-positive quantities.
 2. `add_line` fails with `CannotModifyPlacedOrder` if status is `Placed`.
 3. `add_line` fails with `CurrencyMismatch` if the new line's currency differs from existing lines.
 4. `place` fails with `CannotPlaceEmptyOrder` if there are no lines.
-5. `place` transitions `Draft → Placed`.
+5. `place` transitions `Draft -> Placed`.
 6. `place` fails with `CannotModifyPlacedOrder` on an already-placed order.
 7. `total` sums all line totals; fails on empty order or any underlying money error.
 
@@ -127,19 +131,19 @@ The tests in `test/order_test.gleam` are the spec.
 
 ---
 
-## Hints — what to do
+## Hints
 
 1. **Implement straight first, then refactor.** The naive `add_line` is one big nested `case`. Get it green, then carve out the helpers. You'll *feel* the duplication; that's the signal to refactor.
 2. **Each invariant becomes a guard helper.** One per rule: `no_modify_placed`, `non_empty_sku`, `positive_qty`, `currency_matches`. Each takes a callback (`then: fn() -> Result(...)`). Each returns `Error(SpecificReason)` if the rule is violated, else delegates to the callback.
 3. **Apply them via `use <-`.** Stack the `use <-` lines in `add_line`. The body becomes "run the rules, then do the one record update."
-4. **State checks before arg validation.** If a caller tries `("", -3, ...)` against a *placed* order, the most informative error is `CannotModifyPlacedOrder`, not `EmptySku`. Order matters for the user experience of the error.
-5. **Reuse `no_modify_placed` in `place`.** "You can't re-place a placed order" is the *same* invariant as "you can't modify a placed order." This is the cleanest demonstration of why the helpers aren't just code dedup — they're named domain rules applied wherever they're relevant.
+4. **State checks before arg validation.** The sequence of guards determines which error the caller sees. If a caller tries `("", -3, ...)` against a *placed* order, the most informative error is `CannotModifyPlacedOrder`, not `EmptySku`.
+5. **Reuse `no_modify_placed` in `place`.** "You can't re-place a placed order" is the *same* invariant as "you can't modify a placed order." This is the cleanest demonstration that the helpers aren't code dedup; they're named domain rules applied wherever relevant.
 6. **`Order(..order, lines: [new_line, ..order.lines])`.** Record update + list cons. Without record update you'd be re-typing every field of `Order` to change one. With it, the change is what's interesting.
 7. **For `total`, think in two stages.**
    - Stage 1: line-by-line, multiply `unit_price * quantity`. Each multiply can fail. Use `list.try_map`.
    - Stage 2: sum the per-line totals. Each `money.add` can fail. Use `list.try_fold`, starting from `money.zero(first.unit_price)`.
    - Both stages return `Result(_, money.MoneyError)`. Translate to `OrderError` with `result.map_error`.
-8. **`new` doesn't return `Result`.** A brand-new draft order with an empty line list is always valid. The fact that you can't `place` it yet is enforced *by `place`*, not by `new`. Keep the constructors honest about what they actually validate.
+8. **`new` doesn't return `Result`.** A brand-new draft order with an empty line list is always valid. That you can't `place` it yet is enforced *by `place`*, not by `new`. Keep the constructors honest about what they validate.
 
 If you find yourself writing more than ~10 lines inside `add_line` after
 the refactor, you've gone wrong somewhere.
@@ -288,29 +292,28 @@ pub fn total(order: Order) -> Result(Money, OrderError) {
 
 **Five lines of preconditions, one line of work.** That's `add_line`. Each
 `use <-` line is a named domain rule. The actual mutation is a single
-record-update at the bottom. This is what aggregate code should feel like
-— a flat list of invariants followed by the transition.
+record-update at the bottom. This is what aggregate code should feel like:
+a flat list of invariants followed by the transition.
 
-**Order of preconditions matters.** State checks (`no_modify_placed`)
-before arg validation (`non_empty_sku`, `positive_qty`). If a caller tries
-`("", -3, ...)` against a placed order, the most informative error is
-`CannotModifyPlacedOrder`, not `EmptySku` — the order is locked, the rest
-is moot.
+**Guard sequence matters.** State checks (`no_modify_placed`) come before
+argument validation (`non_empty_sku`, `positive_qty`). A placed order is
+locked; `CannotModifyPlacedOrder` is the informative error, and the
+argument problems are moot.
 
 **Reusing `no_modify_placed` in `place`.** "You can't re-place a placed
 order" is the *same invariant* as "you can't modify a placed order." The
-helper isn't a code-dedup trick — it's a *named domain rule* applied
+helper isn't a code-dedup trick; it's a *named domain rule* applied
 wherever it's relevant.
 
 **`Order(..order, lines: [new_line, ..order.lines])`.** Record update plus
 list cons. Without record update the body would re-list every field of
 `Order` just to change one. With it, the change is what's interesting.
 
-**`total` uses `try_map` then `try_fold`.** Map each line to its line-total
-(each `money.multiply` can fail); fold those with `money.add` (each
-addition can fail). Both stages short-circuit on the first failure.
+**`total` uses `try_map` then `try_fold`.** Map each line to its
+line-total (each `money.multiply` can fail); fold those with `money.add`
+(each addition can fail). Both stages short-circuit on the first failure.
 
-**The `case order.lines` wrapper around `total`.** Two reasons:
+**The `case order.lines` wrapper in `total`.**
 
 - An empty order has no first line to seed `money.zero`. The `[first, ..]` pattern gets us a valid currency to start from.
 - An empty order has no meaningful total to compute. `Error(InvalidOrderTotal)` is the honest answer.
@@ -326,18 +329,18 @@ indistinguishable to the caller. Two options:
 - (a) Define richer `OrderError` variants (`OrderCurrencyMismatch`, `OrderOverflow`) and translate explicitly.
 - (b) Wrap the underlying error: `TotalCalculationFailed(money.MoneyError)`.
 
-Option (b) is what most projects settle on — it preserves the cause
-without exploding the error vocabulary.
+Option (b) is what most projects settle on; it preserves the cause without
+exploding the error vocabulary.
 
 **`OrderLine` is fully internal (no `pub`, no `opaque`).** The original
 spec said `pub opaque type OrderLine`. Both work for opacity, but
 private-only is cleaner: it signals that nobody outside should even *name*
-this type, much less manipulate one. The decision is whether external
-code ever needs to *talk about* an `OrderLine` (e.g., as a return type) —
-in this aggregate, no.
+this type, much less manipulate one. The decision is whether external code
+ever needs to *talk about* an `OrderLine` (e.g., as a return type); in
+this aggregate, no.
 
 **`new_id` doesn't trim.** `new_id("   ")` succeeds with a whitespace ID.
-Probably a bug. Same fix as `customer.new_id`.
+That is probably a bug; the fix is the same trim as `customer.new_id`.
 
 ---
 
@@ -347,7 +350,7 @@ The `Order` module is now a *boundary*. Outside it:
 
 - `OrderLine` doesn't exist as a constructible thing.
 - You can't put an order into an inconsistent state.
-- "Currency homogeneity across lines" isn't even a concept you have to remember — it's enforced by the only door in.
+- "Currency homogeneity across lines" isn't even a concept you have to remember; the only door in enforces it.
 
 When DDD people say *"the aggregate is a consistency boundary,"* this
 module is exactly what they mean. Every aggregate operation either
@@ -358,10 +361,10 @@ explaining why. There is no third outcome.
 
 ## What's next
 
-Kata 5 — **Domain Events.** State transitions that *also* report what
-happened. `add_line` and `place` will return not just the new `Order`,
-but a list of facts (`LineAdded`, `OrderPlaced`) that other parts of the
-system can react to without the aggregate knowing about them.
+Kata 5: **Domain Events.** State transitions that *also* report what
+happened. `add_line` and `place` will return not just the new `Order` but
+also a list of facts (`LineAdded`, `OrderPlaced`). Other parts of the
+system can react to those facts without the aggregate knowing about them.
 
 The toolkit you now have (opacity, smart constructors, `use <-` chains,
 record update) carries straight through. Events are an *additive* change

--- a/docs/book/06_kata_events.md
+++ b/docs/book/06_kata_events.md
@@ -1,32 +1,33 @@
-# 06 — Kata 5: Domain Events
+# 06. Kata 5: Domain Events
 
 ## Concept
 
-Up to now, every operation on the aggregate returned just *the new state*.
-Now they return the new state **plus a list of facts about what happened.**
+Up to now, every operation on the aggregate returned only *the new state*.
+Now they return the new state **plus a list of facts about what
+happened.**
 
-Those facts — domain events — are immutable, named in **past tense**, and
+Those facts, domain events, are immutable, named in **past tense**, and
 carry enough data to describe the transition standalone.
 
-Why bother? Three reasons that compound:
+Why bother? The reasons compound:
 
-- **Decoupling.** Other parts of the system can react to events without the aggregate knowing about them. Send a confirmation email when `OrderPlaced` fires — `Order` doesn't need to know email exists.
+- **Decoupling.** Other parts of the system can react to events without the aggregate knowing about them. Send a confirmation email when `OrderPlaced` fires; `Order` doesn't need to know email exists.
 - **Audit log for free.** The event stream *is* the history. No separate "what happened to this order" code path.
 - **Seed of event sourcing.** Once the aggregate emits a complete event log per state change, you can derive state by replaying events instead of storing it. That's the foundation of CQRS / event sourcing systems.
 
 The naming matters: `OrderPlaced`, not `PlaceOrder`. Events are *things
 that already happened*, not *commands to do something*. (Commands and
-events are duals — see the bonus section at the end.) Mix them and you
+events are duals; the bonus section covers commands.) Mix them and you
 lose the ability to reason about your system.
 
 ---
 
 ## New Gleam fundamentals
 
-You don't actually need much new. The kata is mostly an *additive change*
-to the API — same toolkit, new return shape.
+Little is new. The kata is an *additive change* to the API: same toolkit,
+new return shape.
 
-### Tuples — `#(a, b)`
+### Tuples: `#(a, b)`
 
 Gleam's lightweight pair / triple syntax:
 
@@ -35,9 +36,9 @@ let pair = #(order, [OrderCreated(id, cid)])
 let #(o, events) = pair
 ```
 
-No type definition needed — just a structural pair. Used here to bundle
-"the new state" and "the events emitted by this transition" into one
-return value without inventing a record per operation.
+Tuples need no type definition; the pair is structural. Here it bundles
+the new state and the emitted events into one return value without a
+record per operation.
 
 Pattern matching on tuples works the same as anywhere else:
 
@@ -48,12 +49,11 @@ case order.add_line(o, sku, q, p) {
 }
 ```
 
-### `result.try` chaining (earning its keep)
+### `result.try` earns its keep in `place`
 
-You met `result.try` in Kata 3, but `place` is where it earns its keep.
-`OrderPlaced` carries the total; computing the total can fail. So
-`place` has to chain: validate preconditions → compute total →
-construct event:
+You met `result.try` in Kata 3. `OrderPlaced` carries the total, and
+computing the total can fail, so `place` has to chain: validate
+preconditions, compute the total, then construct the event:
 
 ```gleam
 pub fn place(order: Order) -> Result(#(Order, List(OrderEvent)), OrderError) {
@@ -69,17 +69,17 @@ pub fn place(order: Order) -> Result(#(Order, List(OrderEvent)), OrderError) {
 }
 ```
 
-That `use t <- result.try(total(order))` line is what `use` was designed
-for — it short-circuits the rest of the body if `total` returns `Error`,
-otherwise it binds `t` and continues. Without it the construction would
-nest a `case` inside another `case`.
+That `use t <- result.try(total(order))` line is the payoff: it
+short-circuits the rest of the body when `total` fails, otherwise binds
+`t` and continues. Without it the construction would nest a `case` inside
+another `case`.
 
 ---
 
 ## Task
 
-Modify `src/order.gleam` so `new`, `add_line`, and `place` return both
-the updated aggregate **and** the events emitted:
+Modify `src/order.gleam` so `new`, `add_line`, and `place` return both the
+updated aggregate **and** the events emitted:
 
 ```gleam
 pub type OrderEvent {
@@ -102,30 +102,29 @@ pub fn place(order: Order) -> Result(#(Order, List(OrderEvent)), OrderError)
 
 Rules:
 
-- `new` emits `[OrderCreated(...)]`. It's total — no `Result` wrapper.
+- `new` emits `[OrderCreated(...)]`. It's total; no `Result` wrapper.
 - `add_line` emits `[LineAdded(...)]` on success.
 - `place` emits `[OrderPlaced(...)]` on success, with the total computed at placement time.
-- **Failures emit no events.** Events represent things that *actually happened*, and a failed operation didn't happen. The `Error(...)` branch returns *only* the error — no partial event list.
+- **Failures emit no events.** Events represent things that *actually happened*, and a failed operation didn't happen. The `Error(...)` branch returns *only* the error; no partial event list.
 
-The tests in `test/order_test.gleam` are the per-operation spec. The
-tests in `test/order_scenarios_test.gleam` exercise the aggregate
-through *sequences* of commands (see the "Scenario testing" section
-below).
+The tests in `test/order_test.gleam` are the per-operation spec. The tests
+in `test/order_scenarios_test.gleam` exercise the aggregate through
+*sequences* of commands (see the "Scenario tests" section below).
 
 ---
 
-## Hints — what to do
+## Hints
 
-1. **Implement in this order:** `new_id` → `new` → guard helpers → `add_line` → `total` → `place`. `place` depends on `total`, so do `total` first.
+1. **Implement in this order:** `new_id` -> `new` -> guard helpers -> `add_line` -> `total` -> `place`. `place` depends on `total`, so do `total` first.
 2. **`new` is the simplest function in the file now.** It's total. Construct the order, construct the event, return the tuple. No `Result`, no `case`, no preconditions.
-3. **Failures emit no events.** When a precondition guard returns `Error(...)`, the event list never gets built. The `Ok` branch is the *only* place where you construct events. This falls out naturally from the `use <-` chain — you never reach the event construction if a guard short-circuits.
+3. **Failures emit no events.** When a precondition guard returns `Error(...)`, the event list never gets built. The `Ok` branch is the *only* place where you construct events. This falls out naturally from the `use <-` chain; you never reach the event construction if a guard short-circuits.
 4. **`place` is the interesting one.** Sketch:
    - Guard: order not already placed
    - Check: lines isn't empty (else `CannotPlaceEmptyOrder`)
    - Compute total via `result.try` (else propagate the underlying error)
    - Construct placed order + `OrderPlaced` event
-5. **Don't try to share event-construction code.** Each operation's event has a different shape. Just construct each event inline at its emission site — it's three lines per operation.
-6. **The kata 4 helpers are unchanged.** `no_modify_placed`, `non_empty_sku`, `positive_qty`, `currency_matches` — same signatures, same bodies. They short-circuit before you build anything.
+5. **Don't try to share event-construction code.** Each operation's event has a different shape. Construct each event inline at its emission site; it's three lines per operation.
+6. **The kata 4 helpers are unchanged.** `no_modify_placed`, `non_empty_sku`, `positive_qty`, `currency_matches`: same signatures, same bodies. They short-circuit before you build anything.
 
 ---
 
@@ -273,14 +272,14 @@ pub fn total(order: Order) -> Result(Money, OrderError) {
 ## Walk-through
 
 **`new` is total.** No `Result`. Always succeeds. Returns a tuple of the
-new draft order and a single-element event list. The simplest function
-in the file now.
+new draft order and a single-element event list. The simplest function in
+the file now.
 
-**`add_line` builds the event in the Ok branch only.** The four `use <-`
-guards short-circuit on failure. If we get past them, we construct the
-new line, the new order, and the event — all in three lines. Failures
-return `Error(...)` directly, which means **no event list ever gets
-built on the failure path**. That's the rule: failures aren't facts.
+**`add_line` builds the event in the `Ok` branch only.** The four `use <-`
+guards short-circuit on failure. Past them, the new line, the new order,
+and the event take three lines. Failures return `Error(...)` directly, so
+**the failure path never builds an event list**. That's the rule: failures
+aren't facts.
 
 **`place` is the interesting one.**
 
@@ -296,37 +295,36 @@ case order.lines {
 }
 ```
 
-Three layers of "can fail":
+The layers that can fail:
 
 1. The status check (zero-arg `use <-`).
 2. The empty-lines check (a `case` returning `Error` directly).
 3. The total computation (one-arg `use <-` with `result.try`).
 
-Each short-circuits independently. The body — *constructing the placed
-order and its event* — only runs when all three have passed. This is
-exactly what the chained-failure machinery from earlier chapters was
-built for.
+Each short-circuits independently. The body, constructing the placed order
+and its event, runs only when all three have passed. This is exactly what
+the chained-failure machinery from earlier chapters exists for.
 
-**Why `total` is `pub`.** Two reasons. (a) Callers might want to display
-a running total before placing. (b) The scenario tests want to assert on
-expected totals. Exposing `total` doesn't violate the aggregate boundary
-because it's a pure read — it can't put the order into a bad state.
+**Why `total` is `pub`.** Callers may want to display a running total
+before placing, and the scenario tests assert on expected totals. Exposing
+`total` doesn't violate the aggregate boundary; a pure read can't put the
+order into a bad state.
 
 ---
 
-## Scenario testing — commands as data
+## Scenario tests: commands as data
 
 Once the aggregate has multiple operations that chain together,
 per-operation tests start looking the same:
 
-> build empty order → add line → add line → place → assert.
+> build empty order, add line, add line, place, assert.
 
 That's a lot of ceremony per assertion. The cleaner pattern: make the
-inputs *data*, build a tiny engine to run them, write tests as
-declarative scenarios.
+inputs *data*, build a tiny engine to run them, write tests as declarative
+scenarios.
 
-The full file lives at `test/order_scenarios_test.gleam`. The core is
-~15 lines:
+The full file lives at `test/order_scenarios_test.gleam`. The core is ~15
+lines:
 
 ```gleam
 pub type OrderCommand {
@@ -386,12 +384,12 @@ pub fn add_line_after_place_fails_test() {
 ```
 
 Each scenario is one `let cmds = [...]` followed by one assertion. The
-*sequence* is the data; the *assertion* is the spec. You can read fifty
-of these in two minutes and know exactly what the aggregate does.
+*sequence* is the data; the *assertion* is the spec. You can read fifty of
+these in two minutes and know exactly what the aggregate does.
 
-This pattern scales. The set of failure scenarios is finite and easy to
-enumerate — once they all pass, you have *high confidence* in the
-aggregate's behavior, not just per-operation correctness.
+The pattern scales. The set of failure scenarios is finite; once they all
+pass, you have confidence in the aggregate's behavior, not only
+per-operation correctness.
 
 ---
 
@@ -400,27 +398,26 @@ aggregate's behavior, not just per-operation correctness.
 You've reached the natural endpoint of the aggregate-as-pure-function
 trajectory:
 
-> `aggregate × command → Result(#(new_aggregate, events), error)`
+> `aggregate × command -> Result(#(new_aggregate, events), error)`
 
 That signature is exactly what every CQRS / event-sourcing framework
 treats as the central abstraction. You wrote it without a framework, in
-about 100 lines of Gleam, with the type system enforcing every
-invariant.
+about 100 lines of Gleam, with the type system enforcing every invariant.
 
-In a richer system you wouldn't return events to the caller — you'd
-publish them to an event bus and forget about them. Other bounded
-contexts subscribe and react. Your `Order` aggregate would be entirely
-unaware that a `Shipping` context exists, yet shipping would still
-happen, because shipping listens for `OrderPlaced`. **This decoupling
-is the whole reason events exist as a first-class concept.**
+In a richer system you wouldn't return events to the caller; you'd publish
+them to an event bus and forget about them. Other bounded contexts
+subscribe and react. Your `Order` aggregate would be unaware that a
+`Shipping` context exists, yet shipping would still happen, because
+shipping listens for `OrderPlaced`. **This decoupling is the reason events
+exist as a first-class concept.**
 
 ---
 
-## Bonus — commands as a first-class concept
+## Bonus: commands as a first-class concept
 
-Notice we kept `OrderCommand` in *test code*, not in the domain. That
-was a deliberate choice — the kata is about events, not commands. But
-in a fully event-sourced system, commands graduate to the domain:
+`OrderCommand` lives in *test code*, not the domain, on purpose: the kata
+is about events, not commands. In a fully event-sourced system, commands
+graduate to the domain:
 
 ```gleam
 // commands flow in from the boundary (HTTP, message queue, etc.)
@@ -440,17 +437,17 @@ That single function is the aggregate's entire API. Everything else is
 detail. CQRS frameworks (Axon, EventFlow, akka-persistence-typed) are
 built around exactly this signature.
 
-For the kata, we don't need that abstraction yet — but recognize that
-the scenario engine you just wrote is a *test-time* version of the
-production-time command handler. The pattern is real.
+The kata doesn't need that abstraction yet, but the scenario engine you
+wrote is the test-time version of the production-time command handler. The
+pattern is real.
 
 ---
 
 ## What's next
 
-Kata 6 — **Repositories.** The aggregate has been a pure function so
-far. The next chapter introduces persistence: how the use case loads an
-`Order` from storage, calls `place`, saves the result, and publishes
-events — all without the domain code knowing what storage is.
+Kata 6: **Repositories.** The aggregate has been a pure function so far.
+The next chapter introduces persistence: how the use case loads an `Order`
+from storage, calls `place`, saves the result, and publishes events,
+without the domain code knowing what storage is.
 
 That's where the layering from `00_introduction.md` earns its keep.

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,18 +1,17 @@
-# DDD in Gleam — a textbook
+# DDD in Gleam: a textbook
 
-A walk through the building blocks of Domain-Driven Design, in Gleam. Each
-chapter pairs one DDD concept with the Gleam patterns that make it
-enforceable.
+Each chapter pairs one Domain-Driven Design concept with the Gleam
+patterns that make it enforceable.
 
 ## Contents
 
-- [00 — Introduction](00_introduction.md) — what DDD is, what Gleam is, why pair them.
-- [01 — Gleam fundamentals for Kata 1](01_fundamentals.md) — sum types, records, `opaque`, `Result`, `case`, pattern matching. The bare minimum.
-- [02 — Kata 1: Value Objects (`Email`)](02_kata_email.md) — opaque types and smart constructors.
-- [03 — Kata 2: Value Objects with operations (`Money`)](03_kata_money.md) — composition, `use <-` guards, funneling through `new`.
-- [04 — Kata 3: Entities (`Customer`)](04_kata_customer.md) — identity vs value, ID types, `result.try`.
-- [05 — Kata 4: Aggregates (`Order`)](05_kata_order.md) — internal types, multi-guard chains, `list.try_map` / `list.try_fold`.
-- [06 — Kata 5: Domain Events](06_kata_events.md) — tuples, `result.try` earning its keep, scenario tests with a command engine.
+- [00. Introduction](00_introduction.md): what DDD is, what Gleam is, why they pair.
+- [01. Gleam fundamentals for Kata 1](01_fundamentals.md): sum types, records, `opaque`, `Result`, `case`, pattern matching.
+- [02. Kata 1: Value Objects (`Email`)](02_kata_email.md): opaque types and smart constructors.
+- [03. Kata 2: Value Objects with operations (`Money`)](03_kata_money.md): composition, `use <-` guards, funneling through `new`.
+- [04. Kata 3: Entities (`Customer`)](04_kata_customer.md): identity vs value, ID types, `result.try`.
+- [05. Kata 4: Aggregates (`Order`)](05_kata_order.md): internal types, multi-guard chains, `list.try_map` / `list.try_fold`.
+- [06. Kata 5: Domain Events](06_kata_events.md): tuples, `result.try` earning its keep, scenario tests with a command engine.
 
 ## Prerequisites
 
@@ -27,17 +26,16 @@ enforceable.
 4. Read the walk-through and critique. Compare to your version.
 5. Move on.
 
-The reference solutions live in `src/`. The tests in `test/` are what they
-pass.
+The reference solutions live in `src/`.
 
 ## A note on style
 
-Each chapter follows the same shape, deliberately:
+Each chapter follows one shape:
 
-1. **Concept** — the DDD idea in plain language.
-2. **New Gleam fundamentals** — only what this kata needs that earlier chapters didn't already cover.
-3. **The task** — the function signatures and rules. What to implement.
-4. **Hints — what to do** — enough nudges to unblock without spoiling the design.
-5. **Solution** — the canonical reference, with a walk-through.
-6. **Critique** — what's solid, what's not, what changes when the system grows.
-7. **DDD takeaway** — the property the code now *guarantees*, and why it matters past the toy example.
+1. **Concept**: the DDD idea in plain language.
+2. **New Gleam fundamentals**: only what this kata needs.
+3. **The task**: the function signatures and rules.
+4. **Hints**: nudges that unblock without spoiling the design.
+5. **Solution**: the reference, with a walk-through.
+6. **Critique**: what holds, what doesn't, what changes as the system grows.
+7. **DDD takeaway**: the property the code now *guarantees*, and why it matters past the toy example.


### PR DESCRIPTION
## Why

The book's prose carried slop: buried conclusions, topic-label headers, meta-commentary, em-dashes, reader directives ("Notice..."), and 30-to-40-word sentences. This PR runs all of `docs/book/` through three editing passes (pyramid structure, précis content, ASD-STE100 sentence mechanics) plus the house voice spec. Code is untouched.

## Approach

One commit per file so each diff reviews independently. Prose only: every code fence is byte-identical to master (hash-verified per file).

- **Pyramid**: chapters open with the governing thought instead of throat-clearing. Topic headers became assertions ("Why Gleam" -> "Gleam's constraints map onto DDD's demands"). The kata-template headers (Concept/Task/Hints/Solution/Critique/DDD takeaway) stay as labels since the README documents that shape as deliberate.
- **Précis**: cut repeated refrains, merged redundant paragraphs, removed the stale "(Coming in a later chapter.)" note for Domain Events (chapter 06 exists).
- **STE + voice spec**: em-dashes replaced (semicolons/colons/commas, including H1 separators: `# 00 — Intro` -> `# 00. Intro`, README links updated); reader directives -> plain statements; passives -> active; all sentences now <= 25 words.

Warnings and contracts kept at full precision: task rules, "Forgetting `opaque`...", "Failures emit no events", "Never use raw strings as IDs", the overflow and whitespace-ID caveats.

## Stats

| chapter | lines | headers rewritten | longest sentence |
|---|---|---|---|
| 00_introduction.md | 99 -> 87 | 6 | 23w |
| 01_fundamentals.md | 207 -> 201 | 10 | 21w |
| 02_kata_email.md | 144 -> 141 | 2 | 22w |
| 03_kata_money.md | 258 -> 257 | 4 | 25w |
| 04_kata_customer.md | 225 -> 225 | 3 | 24w |
| 05_kata_order.md | 368 -> 371 | 5 | 22w |
| 06_kata_events.md | 456 -> 453 | 6 | 25w |
| README.md | 43 -> 41 | 1 | 15w |

## Test plan

- Per-file fence check: extracted all fenced blocks before/after, shasums match on every file
- Sentence-length scan: no prose sentence exceeds 25 words
- Em-dash scan of prose: zero hits (fences excluded)